### PR TITLE
Change to only scroll visible image - prevents image gaps; allows viewing tall images

### DIFF
--- a/scripts/jquery.parallax-1.1.3.js
+++ b/scripts/jquery.parallax-1.1.3.js
@@ -55,7 +55,7 @@ http://www.gnu.org/licenses/gpl.html
 					return;
 				}
 
-				$this.css('backgroundPosition', options.offsetX + " " + Math.round((top - pos - (windowHeight/2)) * options.speedFactor + options.offsetY) + "px");
+				$element.css('backgroundPosition', options.offsetX + " " + Math.round((top - pos) * options.speedFactor + options.offsetY) + "px");
 			});
 		}	
         


### PR DESCRIPTION
Great updates. The attached prevents images from scrolling until visible, allowing tall images to be seen in entirety and fixing a visibility problem I had on http://corbiscrave.com.  Also fixes a problem where browsers suddenly resized-tall have a gap below the current image.  

The change moves "background-position" to only current element.  Since only visible slides move the reference to windowHeight goes away; this prevents a pop when entering the viewport. Let me know if screen shots are needed.  

Thanks for your help. 
